### PR TITLE
Remove link to minecraftchat.net

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -213,7 +213,7 @@ The most updated and useful are :
  * [vogonistic/voxel](https://github.com/vogonistic/mineflayer-voxel) - visualize what
    the bot is up to using voxel.js
  * [JonnyD/Skynet](https://github.com/JonnyD/Skynet) -  log player activity onto an online API
- * [MinecraftChat](https://github.com/rom1504/MinecraftChat) (last open source version, built by AlexKvazos) -  Minecraft web based chat client <https://minecraftchat.net/>
+ * [MinecraftChat](https://github.com/rom1504/MinecraftChat) (last open source version, built by AlexKvazos) -  Minecraft web based chat client
  * [Cheese Bot](https://github.com/Minecheesecraft/Cheese-Bot) - Plugin based bot with a clean GUI. Made with Node-Webkit.
  * [Chaoscraft](https://github.com/schematical/chaoscraft) - Minecraft bot using genetic algorithms, see [its youtube videos](https://www.youtube.com/playlist?list=PLLkpLgU9B5xJ7Qy4kOyBJl5J6zsDIMceH)
  * [hexatester/minetelegram](https://github.com/hexatester/minetelegram) -  Minecraft - Telegram bridge, build on top of mineflayer & telegraf.


### PR DESCRIPTION
Minecraftchat.net domain which is is intended to rom1504/Minecraftchat now redirects to sketchy site with "minecraft classic for free". Maybe author of project forgot to renew domain or didn't had money to do it. I'll notify owner of project tomorrow. Currently i removed link.